### PR TITLE
Adjustment on the return method around

### DIFF
--- a/03-spring-aop/src/main/java/com/in28minutes/spring/aop/springaop/aspect/MethodExecutionCalculationAspect.java
+++ b/03-spring-aop/src/main/java/com/in28minutes/spring/aop/springaop/aspect/MethodExecutionCalculationAspect.java
@@ -14,12 +14,14 @@ public class MethodExecutionCalculationAspect {
 	private Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	@Around("com.in28minutes.spring.aop.springaop.aspect.CommonJoinPointConfig.trackTimeAnnotation()")
-	public void around(ProceedingJoinPoint joinPoint) throws Throwable {
+	public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
 		long startTime = System.currentTimeMillis();
 
-		joinPoint.proceed();
+		Object returnProceed = joinPoint.proceed();
 
 		long timeTaken = System.currentTimeMillis() - startTime;
 		logger.info("Time Taken by {} is {}", joinPoint, timeTaken);
+
+		return returnProceed;
 	}
 }


### PR DESCRIPTION
There is an error when the trackTimeAnnotation is called. When using ProceedingJoinPoint and just calling proceed (), the return of this method becomes void, as defined in the around method signature.
To solve this problem, simply return the return of the proceed () method.